### PR TITLE
fix some bugs that may cause segment fault or crash 

### DIFF
--- a/include/DataDependencyGraph.hh
+++ b/include/DataDependencyGraph.hh
@@ -21,6 +21,7 @@ namespace pdg
     void addAliasEdges(llvm::Instruction &inst);
     llvm::AliasResult queryAliasUnderApproximate(llvm::Value &v1, llvm::Value &v2);
 
+    void dumpDataDepGraph(llvm::Function &F);
   private:
     llvm::MemoryDependenceResults *_mem_dep_res;
   };

--- a/include/Graph.hh
+++ b/include/Graph.hh
@@ -46,6 +46,8 @@ namespace pdg
     ValueNodeMap &getValueNodeMap() { return _val_node_map; }
     void dumpGraph();
 
+    std::set<Node *> findNodesReachedByEdges(Node &src, const std::set<EdgeType> &edge_types, bool is_backward = false);
+
   protected:
     ValueNodeMap _val_node_map;
     EdgeSet _edge_set;
@@ -85,7 +87,9 @@ namespace pdg
     void addFormalTreeNodesToGraph(FunctionWrapper &func_w);
     bool isAnnotationCallInst(llvm::Instruction &inst);
     void buildGlobalAnnotationNodes(llvm::Module &M);
+
     void dumpDataDepGraph(llvm::Function &F);
+
 
   private:
     FuncWrapperMap _func_wrapper_map;

--- a/include/LLVMEssentials.hh
+++ b/include/LLVMEssentials.hh
@@ -12,7 +12,6 @@
 #include "llvm/IR/DebugInfo.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/GraphWriter.h"
-#include "llvm/Support/Debug.h"
-#include "llvm/Support/CommandLine.h"
 #include "llvm/ADT/GraphTraits.h"
+#include "llvm/Support/CommandLine.h"
 #endif

--- a/include/ProgramDependencyGraph.hh
+++ b/include/ProgramDependencyGraph.hh
@@ -32,6 +32,9 @@ namespace pdg
       bool canReach(Node &src, Node &dst);
       bool canReach(Node &src, Node &dst, std::set<EdgeType> exclude_edge_types);
 
+      bool isIndirectCallCandidates(CallWrapper &cw, FunctionWrapper &fw);
+      bool checkChildNodes(Tree* src_tree, Tree* dst_tree);
+
     private:
       llvm::Module *_module;
       ProgramGraph *_PDG;

--- a/include/Tree.hh
+++ b/include/Tree.hh
@@ -26,9 +26,9 @@ namespace pdg
       std::vector<TreeNode *> &getChildNodes() { return _children; }
       std::unordered_set<llvm::Value *> &getAddrVars() { return _addr_vars; }
       void computeDerivedAddrVarsFromParent();
-      TreeNode *getParentNode() { return _parent_node; }
+      TreeNode *getParentNode() const { return _parent_node; }
       Tree *getTree() { return _tree; }
-      int getDepth() { return _depth; }
+      int getDepth() const { return _depth; }
       void addAccessTag(AccessTag acc_tag) { _acc_tag_set.insert(acc_tag); }
       std::set<AccessTag> &getAccessTags() { return _acc_tag_set; }
       bool isRootNode() {return _parent_node == nullptr;}

--- a/src/CallWrapper.cpp
+++ b/src/CallWrapper.cpp
@@ -18,13 +18,14 @@ void pdg::CallWrapper::buildActualTreeForArgs(FunctionWrapper &callee_fw)
   while (actual_arg_iter != _arg_list.end())
   {
     Tree* arg_formal_in_tree = callee_fw.getArgFormalInTree(**formal_arg_iter);
-    if (!arg_formal_in_tree) 
-    {
+    if (!arg_formal_in_tree) {
+      // in some case, not each parameter has tree, for example, a function with structure parameter
       actual_arg_iter++;
       formal_arg_iter++;
-      // in some case, not each parameter has tree, for example, a function with structure parameter
       continue;
     }
+      
+
     // build actual in tree, copying the formal_in tree structure at the moment
     Tree* arg_actual_in_tree = new Tree(*arg_formal_in_tree);
     arg_actual_in_tree->setBaseVal(**actual_arg_iter);

--- a/src/DataDependencyGraph.cpp
+++ b/src/DataDependencyGraph.cpp
@@ -100,7 +100,7 @@ void pdg::DataDependencyGraph::addRAWEdgesUnderapproximate(Instruction &inst) {
     auto loadAddr = li->getPointerOperand();
     auto addrNode = g.getNode(*loadAddr);
     if (addrNode == nullptr) {
-        // errs() << "empty addr node load inst " << *loadAddr << " in func " << curFunc->getName().str() << "\n";
+        errs() << "empty addr node load inst " << *loadAddr << " in func " << curFunc->getName().str() << "\n";
         return;
     }
     auto aliasNodes =

--- a/src/DataDependencyGraph.cpp
+++ b/src/DataDependencyGraph.cpp
@@ -1,5 +1,4 @@
 #include "DataDependencyGraph.hh"
-#include "PDGUtils.hh"
 
 char pdg::DataDependencyGraph::ID = 0;
 
@@ -19,7 +18,6 @@ bool pdg::DataDependencyGraph::runOnModule(Module &M)
   {
     if (F.isDeclaration() || F.empty())
       continue;
-    
     _mem_dep_res = &getAnalysis<MemoryDependenceWrapperPass>(F).getMemDep();
     // setup alias query interface for each function
     for (auto inst_iter = inst_begin(F); inst_iter != inst_end(F); inst_iter++)
@@ -27,7 +25,6 @@ bool pdg::DataDependencyGraph::runOnModule(Module &M)
       addDefUseEdges(*inst_iter);
       addAliasEdges(*inst_iter);
       addRAWEdges(*inst_iter);
-      // some RAW could be missing due to the unsound alias analysis, need to swap the alias analysis used by the memory dependency analysis to obtain more precise results.
       addRAWEdgesUnderapproximate(*inst_iter);
     }
   }
@@ -82,8 +79,10 @@ void pdg::DataDependencyGraph::addRAWEdges(Instruction &inst)
   ProgramGraph &g = ProgramGraph::getInstance();
   auto dep_res = _mem_dep_res->getDependency(&inst);
   auto dep_inst = dep_res.getInst();
-  
-  if (!dep_inst || !isa<StoreInst>(dep_inst))
+
+  if (!dep_inst)
+    return;
+  if (!isa<StoreInst>(dep_inst))
     return;
 
   Node *src = g.getNode(inst);
@@ -101,7 +100,7 @@ void pdg::DataDependencyGraph::addRAWEdgesUnderapproximate(Instruction &inst) {
     auto loadAddr = li->getPointerOperand();
     auto addrNode = g.getNode(*loadAddr);
     if (addrNode == nullptr) {
-        errs() << "empty addr node load inst " << *loadAddr << " in func " << curFunc->getName().str() << "\n";
+        // errs() << "empty addr node load inst " << *loadAddr << " in func " << curFunc->getName().str() << "\n";
         return;
     }
     auto aliasNodes =

--- a/src/FunctionWrapper.cpp
+++ b/src/FunctionWrapper.cpp
@@ -42,7 +42,7 @@ void pdg::FunctionWrapper::buildFormalTreeForArgs()
     AllocaInst* arg_alloca_inst = getArgAllocaInst(*arg);
     if (di_local_var == nullptr || arg_alloca_inst == nullptr)
     {
-      errs() << "empty di local var: " << _func->getName().str() << (di_local_var == nullptr) << " - " << (arg_alloca_inst == nullptr) << "\n";
+      // errs() << "empty di local var: " << _func->getName().str() << (di_local_var == nullptr) << " - " << (arg_alloca_inst == nullptr) << "\n";
       continue;
     }
     Tree *arg_formal_in_tree = new Tree(*arg);

--- a/src/FunctionWrapper.cpp
+++ b/src/FunctionWrapper.cpp
@@ -42,7 +42,7 @@ void pdg::FunctionWrapper::buildFormalTreeForArgs()
     AllocaInst* arg_alloca_inst = getArgAllocaInst(*arg);
     if (di_local_var == nullptr || arg_alloca_inst == nullptr)
     {
-      // errs() << "empty di local var: " << _func->getName().str() << (di_local_var == nullptr) << " - " << (arg_alloca_inst == nullptr) << "\n";
+      errs() << "empty di local var: " << _func->getName().str() << (di_local_var == nullptr) << " - " << (arg_alloca_inst == nullptr) << "\n";
       continue;
     }
     Tree *arg_formal_in_tree = new Tree(*arg);

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -176,6 +176,8 @@ void pdg::ProgramGraph::build(Module &M)
         auto ind_call_candidates = call_g.getIndirectCallCandidates(*ci, M);
         if (ind_call_candidates.size() > 0)
           called_func = *ind_call_candidates.begin();
+        else 
+          continue;
       }
       if (!hasFuncWrapper(*called_func))
         continue;

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -109,9 +109,6 @@ void pdg::ProgramGraph::build(Module &M)
     Node * n = new Node(global_var, node_type);
     _val_node_map.insert(std::pair<Value *, Node *>(&global_var, n));
 
-    // outs() << "inserting ";
-    // global_var.print(outs());
-    // outs() << " \n";
     addNode(*n);
   }
 

--- a/src/Graph.cpp
+++ b/src/Graph.cpp
@@ -108,6 +108,10 @@ void pdg::ProgramGraph::build(Module &M)
 
     Node * n = new Node(global_var, node_type);
     _val_node_map.insert(std::pair<Value *, Node *>(&global_var, n));
+
+    // outs() << "inserting ";
+    // global_var.print(outs());
+    // outs() << " \n";
     addNode(*n);
   }
 
@@ -129,10 +133,6 @@ void pdg::ProgramGraph::build(Module &M)
         node_type = GraphNodeType::INST_FUNCALL;
       if (isa<BranchInst>(&*inst_iter))
         node_type = GraphNodeType::INST_BR;
-
-      Node *n = new Node(*inst_iter, node_type);
-
-      // handle values used inside instructions, e.g., tmp gep inst...
       if (isa<StoreInst>(&*inst_iter)) {
         for (auto operand : inst_iter->operand_values()) {
           if (!isa<Instruction>(operand)) {
@@ -141,7 +141,7 @@ void pdg::ProgramGraph::build(Module &M)
           }
         }
       }
-
+      Node *n = new Node(*inst_iter, node_type);
       _val_node_map.insert(std::pair<Value *, Node *>(&*inst_iter, n));
       func_w->addInst(*inst_iter);
       addNode(*n);
@@ -153,10 +153,10 @@ void pdg::ProgramGraph::build(Module &M)
     _func_wrapper_map.insert(std::make_pair(&F, func_w));
   }
 
-  // build call graph
-  auto &call_g = PDGCallGraph::getInstance();
+  auto &call_g = pdg::PDGCallGraph::getInstance();
   if (!call_g.isBuild())
     call_g.build(M);
+
   // handle call sites
   for (auto &F : M)
   {
@@ -170,9 +170,7 @@ void pdg::ProgramGraph::build(Module &M)
     for (auto ci : call_insts)
     {
       auto called_func = pdgutils::getCalledFunc(*ci);
-      if (called_func == nullptr)
-      {
-        // handle indirect call
+      if (called_func == nullptr) {
         auto ind_call_candidates = call_g.getIndirectCallCandidates(*ci, M);
         if (ind_call_candidates.size() > 0)
           called_func = *ind_call_candidates.begin();
@@ -389,11 +387,42 @@ void pdg::ProgramGraph::buildGlobalAnnotationNodes(Module &M)
   }
 }
 
+
+std::set<pdg::Node *> pdg::GenericGraph::findNodesReachedByEdges(pdg::Node &src, const std::set<EdgeType> &edge_types, bool is_backward)
+{
+  std::set<Node *> ret;
+  std::queue<Node *> node_queue;
+  node_queue.push(&src);
+  std::set<Node *> visited;
+  while (!node_queue.empty())
+  {
+    Node *current_node = node_queue.front();
+    node_queue.pop();
+    if (visited.find(current_node) != visited.end())
+      continue;
+    visited.insert(current_node);
+    ret.insert(current_node);
+    Node::EdgeSet edge_set;
+    if (is_backward)
+      edge_set = current_node->getInEdgeSet();
+    else 
+      edge_set = current_node->getOutEdgeSet();
+    for (auto edge : edge_set)
+    {
+      if (edge_types.find(edge->getEdgeType()) == edge_types.end())
+        continue;
+      node_queue.push(edge->getDstNode());
+    }
+  }
+  return ret;
+}
+
+
 void pdg::ProgramGraph::dumpDataDepGraph(Function &F) {
   for (auto iter1 = inst_begin(F); iter1 != inst_end(F); iter1++) {
     for (auto iter2 = inst_begin(F); iter2 != inst_end(F); iter2++) {
       if (&*iter1 == &*iter2)
-        continue;
+       continue;
       Node* n1 = getNode(*iter1);
       Node* n2 = getNode(*iter2);
       assert((n1 && n2) && "cannot process null node");

--- a/src/PDGCallGraph.cpp
+++ b/src/PDGCallGraph.cpp
@@ -93,6 +93,8 @@ bool pdg::PDGCallGraph::isTypeEqual(Type& t1, Type &t2)
   return (t1_name == t2_name);
 }
 
+
+
 std::set<Function *> pdg::PDGCallGraph::getIndirectCallCandidates(CallInst &ci, Module &M)
 {
   Type *call_func_ty = ci.getFunctionType();
@@ -102,8 +104,9 @@ std::set<Function *> pdg::PDGCallGraph::getIndirectCallCandidates(CallInst &ci, 
   {
     if (F.isDeclaration() || F.empty())
       continue;
-    if (isFuncSignatureMatch(ci, F))
+    if (isFuncSignatureMatch(ci, F)) {
       ind_call_cand.insert(&F);
+    }
   }
   return ind_call_cand;
 }

--- a/src/PDGUtils.cpp
+++ b/src/PDGUtils.cpp
@@ -24,7 +24,7 @@ uint64_t pdg::pdgutils::getGEPOffsetInBits(Module& M, StructType &struct_type, G
   auto const struct_layout = data_layout.getStructLayout(&struct_type);
   if (gep_offset >= struct_type.getNumElements())
   {
-    errs() << "dubious gep access outof bound: " << gep << " in func " << gep.getFunction()->getName() << "\n";
+    //errs() << "dubious gep access outof bound: " << gep << " in func " << gep.getFunction()->getName() << "\n";
     return INT_MIN;
   }
   uint64_t field_bit_offset = struct_layout->getElementOffsetInBits(gep_offset);
@@ -390,7 +390,6 @@ std::string& pdg::pdgutils::rtrim(std::string& s, const char* t)
     s.erase(s.find_last_not_of(t) + 1);
     return s;
 }
-
 
 // check if i1 is precede of i2
 bool pdg::pdgutils::isPrecedeInst(Instruction &i1, Instruction &i2, Function& F) 

--- a/src/ProgramDependencyGraph.cpp
+++ b/src/ProgramDependencyGraph.cpp
@@ -142,15 +142,11 @@ void pdg::ProgramDependencyGraph::connectCallerAndCallee(CallWrapper &cw, Functi
     // step 2: connect actual in -> formal in
     auto actual_in_tree = cw.getArgActualInTree(*actual_arg);
     auto formal_in_tree = fw.getArgFormalInTree(*formal_arg);
-    if (actual_in_tree == nullptr)
-      continue;
     _PDG->addTreeNodesToGraph(*actual_in_tree);
     connectInTrees(actual_in_tree, formal_in_tree, EdgeType::PARAMETER_IN);
     // step 3: connect actual out -> formal out
     auto actual_out_tree = cw.getArgActualOutTree(*actual_arg);
     auto formal_out_tree = fw.getArgFormalOutTree(*formal_arg);
-    if (actual_out_tree == nullptr)
-      continue;
     _PDG->addTreeNodesToGraph(*actual_out_tree);
     connectOutTrees(formal_out_tree, actual_out_tree, EdgeType::PARAMETER_OUT);
   }

--- a/src/ProgramDependencyGraph.cpp
+++ b/src/ProgramDependencyGraph.cpp
@@ -67,6 +67,8 @@ void pdg::ProgramDependencyGraph::connectInTrees(Tree *src_tree, Tree *dst_tree,
                                                  EdgeType edge_type) {
   if (src_tree->size() != dst_tree->size())
     return;
+  if (src_tree == nullptr || dst_tree == nullptr)
+    return;
   auto src_tree_root_node = src_tree->getRootNode();
   auto dst_tree_root_node = dst_tree->getRootNode();
   std::queue<std::pair<TreeNode *, TreeNode *>> node_pairs_queue;
@@ -135,6 +137,9 @@ void pdg::ProgramDependencyGraph::connectCallerAndCallee(CallWrapper &cw,
     // step 2: connect actual in -> formal in
     auto actual_in_tree = cw.getArgActualInTree(*actual_arg);
     auto formal_in_tree = fw.getArgFormalInTree(*formal_arg);
+    // 为什么这里会有nullptr?
+    if (actual_in_tree == nullptr || formal_in_tree == nullptr)
+      continue;
     _PDG->addTreeNodesToGraph(*actual_in_tree);
     connectInTrees(actual_in_tree, formal_in_tree, EdgeType::PARAMETER_IN);
     // step 3: connect actual out -> formal out

--- a/src/Tree.cpp
+++ b/src/Tree.cpp
@@ -7,6 +7,9 @@ pdg::TreeNode::TreeNode(const TreeNode &tree_node) : Node(tree_node.getNodeType(
   _func = tree_node.getFunc();
   _node_di_type = tree_node.getDIType();
   _node_type = tree_node.getNodeType();
+  _depth = tree_node.getDepth();
+  _parent_node = tree_node.getParentNode();
+  _func = tree_node.getFunc();
 }
 
 pdg::TreeNode::TreeNode(DIType *di_type, int depth, TreeNode *parent_node, Tree *tree, GraphNodeType node_type) : Node(node_type)
@@ -15,6 +18,8 @@ pdg::TreeNode::TreeNode(DIType *di_type, int depth, TreeNode *parent_node, Tree 
   _depth = depth;
   _parent_node = parent_node;
   _tree = tree;
+  if (parent_node != nullptr)
+    _func = parent_node->getFunc();
 }
 
 pdg::TreeNode::TreeNode(Function &f, DIType *di_type, int depth, TreeNode *parent_node, Tree *tree, GraphNodeType node_type) : Node(node_type)
@@ -87,8 +92,12 @@ void pdg::TreeNode::computeDerivedAddrVarsFromParent()
 
   for (auto base_node_addr_var : base_node_addr_vars)
   {
+    if (base_node_addr_var == nullptr)
+      continue;
     for (auto user : base_node_addr_var->users())
     {
+      if (user == nullptr)
+        continue;
       // handle load instruction, field should not get the load inst from the sturct pointer.
       if (LoadInst *li = dyn_cast<LoadInst>(user))
       {

--- a/src/Tree.cpp
+++ b/src/Tree.cpp
@@ -18,8 +18,6 @@ pdg::TreeNode::TreeNode(DIType *di_type, int depth, TreeNode *parent_node, Tree 
   _depth = depth;
   _parent_node = parent_node;
   _tree = tree;
-  if (parent_node != nullptr)
-    _func = parent_node->getFunc();
 }
 
 pdg::TreeNode::TreeNode(Function &f, DIType *di_type, int depth, TreeNode *parent_node, Tree *tree, GraphNodeType node_type) : Node(node_type)
@@ -79,7 +77,7 @@ void pdg::TreeNode::computeDerivedAddrVarsFromParent()
   // handle struct pointer
   auto grand_parent_node = _parent_node->getParentNode();
   // TODO: now hanlde struct specifically, but should also verify on other aggregate pointer types
-  if (grand_parent_node != nullptr && dbgutils::isStructType(*_parent_node->getDIType()) && dbgutils::isStructPointerType(*grand_parent_node->getDIType()))
+  if (grand_parent_node != nullptr && dbgutils::isStructType(*(_parent_node->getDIType())) && dbgutils::isStructPointerType(*(grand_parent_node->getDIType())))
   {
     base_node_addr_vars = grand_parent_node->getAddrVars();
   }
@@ -96,8 +94,6 @@ void pdg::TreeNode::computeDerivedAddrVarsFromParent()
       continue;
     for (auto user : base_node_addr_var->users())
     {
-      if (user == nullptr)
-        continue;
       // handle load instruction, field should not get the load inst from the sturct pointer.
       if (LoadInst *li = dyn_cast<LoadInst>(user))
       {


### PR DESCRIPTION
1. When using arg_formal_in_tree to construct arg_actual_out_tree or other trees, it will call `pdg::TreeNode::TreeNode(const TreeNode &tree_node)`, but its _parent_node field remains uninitialized. While in `expandNode()`, new_child_node will call `computeDerivedAddrVarsFromParent()`, in which may access root_node's parent_node through `getParentNode()`, while root_node's parent_node is still uninitialized, if its value is illegal, when use it as pointer, such as `grand_parent_node->getAddrVars()`, there will be a segment fault.
2. I have met a confusing case, in `pdg::ProgramDependencyGraph::connectInterprocDependencies`, for indirect calls, the number of nodes for caller's ret_actual_in_tree and callee's ret_formal_in_tree may unequal, which will cause `assert(src->numOfChild() == dst->numOfChild());` in `pdg::ProgramDependencyGraph::connectInTrees` failed, so for each indirectCallCandidate, check the number of tree nodes before call `connectCallerAndCallee`, only when callee's nodes equals to caller's nodes, callee can be indeed indirectCallCandidate  