### PR TITLE
fix Tree initialization

### DIFF
--- a/include/Tree.hh
+++ b/include/Tree.hh
@@ -159,9 +159,9 @@ namespace pdg
     void addAccessForAllNodes(AccessTag accTag);
 
   private:
-    llvm::Value *_baseVal;
-    TreeNode *_rootNode;
-    int _size;
+    llvm::Value *_baseVal = nullptr;
+    TreeNode *_rootNode = nullptr;
+    int _size = 0;
   };
 } // namespace pdg
 


### PR DESCRIPTION
Initializes the `Tree::_size` member to 0.

This fixes a bug where an uninitialized `_size` would cause size checks in `connectInTrees` and `connectOutTrees` to fail, preventing the trees from connecting.

https://github.com/ARISTODE/program-dependence-graph/blob/8632566525b7e020858f5d6496a7be196386636a/src/ProgramDependencyGraph.cpp#L84-L87

Note: This bug likely affects other active branches.
